### PR TITLE
#90: Payeezy integration; selector name changed

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
+++ b/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
@@ -7,8 +7,8 @@ if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
 }
 
-define ('CHECKOUT_ONE_CURRENT_VERSION', '1.2.0');
-define ('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2017-04-23');
+define ('CHECKOUT_ONE_CURRENT_VERSION', '1.2.1-beta1');
+define ('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2017-06-xx');
 $version_release_date = CHECKOUT_ONE_CURRENT_VERSION . ' (' . CHECKOUT_ONE_CURRENT_UPDATE_DATE . ')';
 
 $configurationGroupTitle = 'One-Page Checkout Settings';

--- a/docs/one_page_checkout/readme.html
+++ b/docs/one_page_checkout/readme.html
@@ -73,7 +73,7 @@ th { background-color: #eee; }
 
 <body>
   <h1>One-Page Checkout <span class="smaller">for Zen Cart v1.5.4 (and later)</span></h1>
-  <h3>Version 1.2.0 by lat9</h3>
+  <h3>Version 1.2.1 by lat9</h3>
   <h3>Copyright &copy; 2013-2017 <a href="http://vinosdefrutastropicales.com" target="_blank">Vinos de Frutas Tropicales</a>. All rights reserved.</h3>
   <p><b>Credits:</b></p>
   <ol>
@@ -417,6 +417,13 @@ th { background-color: #eee; }
             <div id="changes">
               <p>You can view the details of these changes on the plugin's <a href="https://github.com/lat9/one_page_checkout/issues" target="_blank">GitHub repository.</a> Changes to the plugin's default templates are identified in <span class="template-changed">this</span> color; remember to merge those changes with any template-override version you might have created!</p>
               <ul>
+                <li>v1.2.1, 2017-06-xx:<ul>
+                  <li>BUGFIX: Use &quot;standard&quot; selector name for submit button (Payeezy integration).</li>
+                  <li>The following files were affected:<ol>
+                    <li><span class="template-changed">/includes/templates/template_default/templates/tpl_checkout_one_default.php</span></li>
+                    <li>/YOUR_ADMIN/includes/init_includes/init_checkout_one.php</li>
+                  </ol></li>
+                </ul></li>
                 <li>v1.2.0, 2017-04-23:<ul>
                   <li>BUGFIX: Correct &quot;Shipping, same as Billing&quot; processing.</li>
                   <li>CHANGE: Add <em>Edit</em> button to shopping-cart block on checkout pages.</li>

--- a/includes/templates/template_default/templates/tpl_checkout_one_default.php
+++ b/includes/templates/template_default/templates/tpl_checkout_one_default.php
@@ -390,7 +390,7 @@ if ($shipping_module_available && $payment_module_available) {
 <?php
     }
 ?>
-  <div id="checkoutOneSubmit" class="buttonRow forward"><?php echo zen_image_submit (BUTTON_IMAGE_CHECKOUT_ONE_CONFIRM, BUTTON_CHECKOUT_ONE_CONFIRM_ALT, 'id="confirm-order" name="confirm_order" onclick="submitFunction(' .zen_user_has_gv_account($_SESSION['customer_id']).','.$order->info['total'] . '); setOrderConfirmed (1);"') . zen_draw_hidden_field ('order_confirmed', '1', 'id="confirm-the-order"') . zen_draw_hidden_field ('current_order_total', '0', 'id="current-order-total"'); ?></div>
+  <div id="paymentSubmit" class="buttonRow forward"><?php echo zen_image_submit (BUTTON_IMAGE_CHECKOUT_ONE_CONFIRM, BUTTON_CHECKOUT_ONE_CONFIRM_ALT, 'id="confirm-order" name="confirm_order" onclick="submitFunction(' .zen_user_has_gv_account($_SESSION['customer_id']).','.$order->info['total'] . '); setOrderConfirmed (1);"') . zen_draw_hidden_field ('order_confirmed', '1', 'id="confirm-the-order"') . zen_draw_hidden_field ('current_order_total', '0', 'id="current-order-total"'); ?></div>
   <div id="checkoutOneEmail" class="forward clearRight"><?php echo sprintf (TEXT_CONFIRMATION_EMAILS_SENT_TO, $order->customer['email_address']); ?></div>
 <?php
 }


### PR DESCRIPTION
Update the `id` of the checkout-confirmation button to enable
interoperation.